### PR TITLE
update mpasi decomp files for ARRM 60to6 and pe layout on onyx

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -8491,11 +8491,11 @@
           <ntasks_atm>64</ntasks_atm>
           <ntasks_lnd>64</ntasks_lnd>
           <ntasks_rof>64</ntasks_rof>
-          <ntasks_ice>4096</ntasks_ice>
+          <ntasks_ice>2400</ntasks_ice>
           <ntasks_ocn>8192</ntasks_ocn>
           <ntasks_glc>64</ntasks_glc>
           <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>4096</ntasks_cpl>
+          <ntasks_cpl>2400</ntasks_cpl>
           </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -8512,7 +8512,7 @@
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>4096</rootpe_ocn>
+          <rootpe_ocn>2400</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -180,8 +180,8 @@ def buildnml(case, caseroot, compname):
     elif ice_grid == 'oARRM60to6':
         grid_date += '180803'
         grid_prefix += 'seaice.ARRM60to6'
-        decomp_date += '180820'
-        decomp_prefix += 'mpas-cice.graph.info.'
+        decomp_date += '190603'
+        decomp_prefix += 'mpas-seaice.graph.v2.1.'
 
 
     #--------------------------------------------------------------------


### PR DESCRIPTION

This just updates the ARRM 60to6 mpas ice decomp files to the latest version.  These seem to perform better.

This also updates the pe layout for the ARRM 60to6 configuration but just on onyx.