### PR TITLE
New namelist switch for solar rad VIS/NIR fluxes in RRTMG (PR 7488)

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -181,6 +181,7 @@ _TESTS = {
             "SMS_D_Ln5.ne4_oQU240.F2010.eam-cflx_cpl_2",
             "ERS.ne4pg2_oQU480.F2010.eam-p3",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-p3",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-rrtmg_split",
             )
         },
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4503,7 +4503,9 @@ Default: FALSE
 
 <entry id="rad_asym_splt" type="logical"  category="radiation"
 group="radiation_nl" valid_values="" > 
-Split radiation asymmetrically between VIS/NIR, coef for VIS
+Split surface insolation asymmetrically between VIS/NIR. 
+Coefficient determines fraction of VIS flux (i.e., less than 0.7 um) 
+in RRTMG overlap band that spans 0.625–0.778 um
 Default: FALSE
 </entry>
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4501,6 +4501,12 @@ Return fluxes per band in addition to the total fluxes.
 Default: FALSE
 </entry>
 
+<entry id="rad_asym_splt" type="logical"  category="radiation"
+group="radiation_nl" valid_values="" > 
+Split radiation asymmetrically between VIS/NIR, coef for VIS
+Default: FALSE
+</entry>
+
 <entry id="use_rad_dt_cosz" type="logical"  category="radiation"
        group="radiation_nl" valid_values="" >
 If true, then use the radiation timestep for all cosz calculations.

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/rrtmg_split/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/rrtmg_split/user_nl_eam
@@ -1,0 +1,1 @@
+rad_asym_splt = .true.

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
@@ -238,7 +238,7 @@
                                                         !    Dimensions: (ncol)
       real(kind=r8), intent(in) :: aldif(:)             ! Near-IR surface albedo: diffuse rad
                                                         !    Dimensions: (ncol)
-      real(kind=r8), intent(in) :: vis_frc              ! Fraction of flux blueward of 0.7microns 
+      real(kind=r8), intent(in) :: vis_frc              ! Fraction of surface insolation blueward of 0.7microns
                                                         ! in rrtmg_sw split band
       integer, intent(in) :: dyofyr                     ! Day of the year (used to get Earth/Sun
                                                         !  distance if adjflx not provided)
@@ -449,7 +449,6 @@
       real(kind=r8) :: znifu(nlay+2)          ! temporary near-IR downward shortwave flux (w/m2)
       real(kind=r8) :: znicu(nlay+2)          ! temporary clear sky near-IR downward shortwave flux (w/m2)
 
-
 ! Optional output fields 
       real(kind=r8) :: swnflx(nlay+2)         ! Total sky shortwave net flux (W/m2)
       real(kind=r8) :: swnflxc(nlay+2)        ! Clear sky shortwave net flux (W/m2)
@@ -577,10 +576,8 @@
 ! Transfer albedo, cloud and aerosol properties into arrays for 2-stream radiative transfer 
 
 ! Surface albedo
-         
 !  Near-IR bands 16-24 and 29 (1-9 and 14), 820-16000 cm-1, 0.625-12.195 microns
 !         do ib=1,9
-
          do ib=1,8
             albdir(ib) = aldir(iplon)
             albdif(ib) = aldif(iplon)

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
@@ -87,7 +87,7 @@
             (lchnk   ,ncol    ,nlay    ,icld    ,          &
              play    ,plev    ,tlay    ,tlev    ,tsfc    , &
              h2ovmr  ,o3vmr   ,co2vmr  ,ch4vmr  ,o2vmr   ,n2ovmr  , &
-             asdir   ,asdif   ,aldir   ,aldif   , &
+             asdir   ,asdif   ,aldir   ,aldif   , vis_frc, &
              coszen  ,adjes   ,dyofyr  ,solvar, &
              inflgsw ,iceflgsw,liqflgsw, &
              cldfmcl ,taucmcl ,ssacmcl ,asmcmcl ,fsfcmcl, &
@@ -238,7 +238,8 @@
                                                         !    Dimensions: (ncol)
       real(kind=r8), intent(in) :: aldif(:)             ! Near-IR surface albedo: diffuse rad
                                                         !    Dimensions: (ncol)
-
+      real(kind=r8), intent(in) :: vis_frc              ! Fraction of flux blueward of 0.7microns 
+                                                        ! in rrtmg_sw split band
       integer, intent(in) :: dyofyr                     ! Day of the year (used to get Earth/Sun
                                                         !  distance if adjflx not provided)
       real(kind=r8), intent(in) :: adjes                ! Flux adjustment for Earth/Sun distance
@@ -448,6 +449,7 @@
       real(kind=r8) :: znifu(nlay+2)          ! temporary near-IR downward shortwave flux (w/m2)
       real(kind=r8) :: znicu(nlay+2)          ! temporary clear sky near-IR downward shortwave flux (w/m2)
 
+
 ! Optional output fields 
       real(kind=r8) :: swnflx(nlay+2)         ! Total sky shortwave net flux (W/m2)
       real(kind=r8) :: swnflxc(nlay+2)        ! Clear sky shortwave net flux (W/m2)
@@ -575,8 +577,10 @@
 ! Transfer albedo, cloud and aerosol properties into arrays for 2-stream radiative transfer 
 
 ! Surface albedo
+         
 !  Near-IR bands 16-24 and 29 (1-9 and 14), 820-16000 cm-1, 0.625-12.195 microns
 !         do ib=1,9
+
          do ib=1,8
             albdir(ib) = aldir(iplon)
             albdif(ib) = aldif(iplon)
@@ -584,9 +588,12 @@
          albdir(nbndsw) = aldir(iplon)
          albdif(nbndsw) = aldif(iplon)
 !  Set band 24 (or, band 9 counting from 1) to use linear average of UV/visible
-!  and near-IR values, since this band straddles 0.7 microns: 
-         albdir(9) = 0.5*(aldir(iplon) + asdir(iplon))
-         albdif(9) = 0.5*(aldif(iplon) + asdif(iplon))
+!  and near-IR values, since this band straddles 0.7 microns:
+! JPT 20250702: Namelist switch "rad_asym_splt" shifts the average flux + albedo of the split
+! band from 50/50, to a more realistic 55.5/44.5 between the VIS and NIR bands, as described in Tolento et al. (2025).
+! Default is still 50/50, which produces a warming bias over cryospheric surfaces 
+         albdir(9) = (1.0-vis_frc)*aldir(iplon) + vis_frc*asdir(iplon)
+         albdif(9) = (1.0-vis_frc)*aldif(iplon) + vis_frc*asdif(iplon)
 !  UV/visible bands 25-28 (10-13), 16000-50000 cm-1, 0.200-0.625 micron
          do ib=10,13
             albdir(ib) = asdir(iplon)
@@ -695,7 +702,7 @@
 
          call spcvmc_sw &
              (lchnk, iplon, nlay, istart, iend, icpr, idelm, iout, &
-              pavel, tavel, pz, tz, tbound, albdif, albdir, &
+              pavel, tavel, pz, tz, tbound, albdif, albdir, vis_frc, &
               zcldfmc, ztaucmc, zasycmc, zomgcmc, ztaormc, &
               ztaua, zasya, zomga, cossza, coldry, wkl, adjflux, &	 
               laytrop, layswtch, laylow, jp, jt, jt1, &

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
@@ -36,7 +36,7 @@
 ! ---------------------------------------------------------------------------
       subroutine spcvmc_sw &
             (lchnk, iplon, nlayers, istart, iend, icpr, idelm, iout, &
-             pavel, tavel, pz, tz, tbound, palbd, palbp, &
+             pavel, tavel, pz, tz, tbound, palbd, palbp, vis_frc, &
              pcldfmc, ptaucmc, pasycmc, pomgcmc, ptaormc, &
              ptaua, pasya, pomga, prmu0, coldry, wkl, adjflux, &
              laytrop, layswtch, laylow, jp, jt, jt1, &
@@ -131,6 +131,8 @@
                                                                  !   Dimensions: (nbndsw)
       real(kind=r8), intent(in) :: palbp(:)                    ! surface albedo (direct)
                                                                  !   Dimensions: (nbndsw)
+      real(kind=r8), intent(in) :: vis_frc                     ! Fraction of flux blueward of 0.7microns
+                                                               ! in rrtmg_sw split band
       real(kind=r8), intent(in) :: prmu0                       ! cosine of solar zenith angle
       real(kind=r8), intent(in) :: pcldfmc(:,:)                ! cloud fraction [mcica]
                                                                  !   Dimensions: (nlayers,ngptsw)
@@ -624,24 +626,28 @@
                      puvcddir(ikl) = puvcddir(ikl) + zincflx(iw)*ztdbtc(jk)
                   endif
 ! band 9 is half-NearIR and half-Visible
+! JPT 20250702: Namelist switch "rad_asym_splt" shifts the average flux+albedo of the split
+! band from 50/50, to a more realistic 55.5/44.5 between the VIS and NIR coupling bands,
+! as described in Tolento et al. (2025)
+! Default is still 50/50, which produces a warming bias over cryospheric surfaces
                else if (ibm == 9) then  
-                  puvcd(ikl) = puvcd(ikl) + 0.5_r8*zincflx(iw)*zcd(jk,iw)
-                  puvfd(ikl) = puvfd(ikl) + 0.5_r8*zincflx(iw)*zfd(jk,iw)
-                  pnicd(ikl) = pnicd(ikl) + 0.5_r8*zincflx(iw)*zcd(jk,iw)
-                  pnifd(ikl) = pnifd(ikl) + 0.5_r8*zincflx(iw)*zfd(jk,iw)
+                  puvcd(ikl) = puvcd(ikl) + vis_frc*zincflx(iw)*zcd(jk,iw)
+                  puvfd(ikl) = puvfd(ikl) + vis_frc*zincflx(iw)*zfd(jk,iw)
+                  pnicd(ikl) = pnicd(ikl) + (1.0-vis_frc)*zincflx(iw)*zcd(jk,iw)
+                  pnifd(ikl) = pnifd(ikl) + (1.0-vis_frc)*zincflx(iw)*zfd(jk,iw)
                   if (idelm .eq. 0) then
-                     puvfddir(ikl) = puvfddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt_nodel(jk)
-                     puvcddir(ikl) = puvcddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc_nodel(jk)
-                     pnifddir(ikl) = pnifddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt_nodel(jk)
-                     pnicddir(ikl) = pnicddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc_nodel(jk)
+                     puvfddir(ikl) = puvfddir(ikl) + vis_frc*zincflx(iw)*ztdbt_nodel(jk)
+                     puvcddir(ikl) = puvcddir(ikl) + vis_frc*zincflx(iw)*ztdbtc_nodel(jk)
+                     pnifddir(ikl) = pnifddir(ikl) + (1.0-vis_frc)*zincflx(iw)*ztdbt_nodel(jk)
+                     pnicddir(ikl) = pnicddir(ikl) + (1.0-vis_frc)*zincflx(iw)*ztdbtc_nodel(jk)
                   elseif (idelm .eq. 1) then
-                     puvfddir(ikl) = puvfddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt(jk)
-                     puvcddir(ikl) = puvcddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc(jk)
-                     pnifddir(ikl) = pnifddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt(jk)
-                     pnicddir(ikl) = pnicddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc(jk)
+                     puvfddir(ikl) = puvfddir(ikl) + vis_frc*zincflx(iw)*ztdbt(jk)
+                     puvcddir(ikl) = puvcddir(ikl) + vis_frc*zincflx(iw)*ztdbtc(jk)
+                     pnifddir(ikl) = pnifddir(ikl) + (1.0-vis_frc)*zincflx(iw)*ztdbt(jk)
+                     pnicddir(ikl) = pnicddir(ikl) + (1.0-vis_frc)*zincflx(iw)*ztdbtc(jk)
                   endif
-                  pnicu(ikl) = pnicu(ikl) + 0.5_r8*zincflx(iw)*zcu(jk,iw)
-                  pnifu(ikl) = pnifu(ikl) + 0.5_r8*zincflx(iw)*zfu(jk,iw)
+                  pnicu(ikl) = pnicu(ikl) + (1.0-vis_frc)*zincflx(iw)*zcu(jk,iw)
+                  pnifu(ikl) = pnifu(ikl) + (1.0-vis_frc)*zincflx(iw)*zfu(jk,iw)
 ! Accumulate direct fluxes for near-IR bands
                else if (ibm == 14 .or. ibm <= 8) then  
                   pnicd(ikl) = pnicd(ikl) + zincflx(iw)*zcd(jk,iw)

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
@@ -131,7 +131,7 @@
                                                                  !   Dimensions: (nbndsw)
       real(kind=r8), intent(in) :: palbp(:)                    ! surface albedo (direct)
                                                                  !   Dimensions: (nbndsw)
-      real(kind=r8), intent(in) :: vis_frc                     ! Fraction of flux blueward of 0.7microns
+      real(kind=r8), intent(in) :: vis_frc                     ! Fraction of surface insolation blueward of 0.7microns
                                                                ! in rrtmg_sw split band
       real(kind=r8), intent(in) :: prmu0                       ! cosine of solar zenith angle
       real(kind=r8), intent(in) :: pcldfmc(:,:)                ! cloud fraction [mcica]

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -921,7 +921,7 @@ end function radiation_nextsw_cday
     real(r8) clmed(pcols)                      !       "     mid  cloud cover
     real(r8) clhgh(pcols)                      !       "     hgh  cloud cover
     real(r8) :: ftem(pcols,pver)               ! Temporary workspace for outfld variables
-    real(r8) :: vis_frc                        ! Fraction of flux blueward of 0.7microns 
+    real(r8) :: vis_frc                        ! Fraction of surface insolation blueward of 0.7microns 
                                                ! in rrtmg_sw split band 
     ! combined cloud radiative parameters are "in cloud" not "in cell"
     real(r8) :: c_cld_tau    (nbndsw,pcols,pver) ! cloud extinction optical depth

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -72,6 +72,7 @@ integer :: irad_always = 0 ! Specifies length of time in timesteps (positive)
                            ! run continuously from the start of an
                            ! initial or restart run
 logical :: spectralflux  = .false. ! calculate fluxes (up and down) per band.
+logical :: rad_asym_splt  = .false.
 
 logical :: use_rad_dt_cosz  = .false. ! if true, uses the radiation dt for all cosz calculations !BSINGH - Added for solar insolation calc.
 
@@ -120,7 +121,7 @@ subroutine radiation_readnl(nlfile, dtime_in)
    ! Variables defined in namelist
    namelist /radiation_nl/ iradsw, iradlw, irad_always, &
                            use_rad_dt_cosz, spectralflux, &
-                           do_spa_optics
+                           do_spa_optics, rad_asym_splt
 
    ! Read the namelist, only if called from master process
    ! TODO: better documentation and cleaner logic here?
@@ -146,6 +147,7 @@ subroutine radiation_readnl(nlfile, dtime_in)
    call mpibcast(use_rad_dt_cosz, 1, mpi_logical, mstrid, mpicom, ierr)
    call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
    call mpibcast(do_spa_optics, 1, mpi_logical, mstrid, mpicom, ierr)
+   call mpibcast(rad_asym_splt, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
    ! Make sure nobody tries to use SPA optics with RRTMG
@@ -918,8 +920,9 @@ end function radiation_nextsw_cday
     real(r8) cllow(pcols)                      !       "     low  cloud cover
     real(r8) clmed(pcols)                      !       "     mid  cloud cover
     real(r8) clhgh(pcols)                      !       "     hgh  cloud cover
-    real(r8) :: ftem(pcols,pver)              ! Temporary workspace for outfld variables
-
+    real(r8) :: ftem(pcols,pver)               ! Temporary workspace for outfld variables
+    real(r8) :: vis_frc                        ! Fraction of flux blueward of 0.7microns 
+                                               ! in rrtmg_sw split band 
     ! combined cloud radiative parameters are "in cloud" not "in cell"
     real(r8) :: c_cld_tau    (nbndsw,pcols,pver) ! cloud extinction optical depth
     real(r8) :: c_cld_tau_w  (nbndsw,pcols,pver) ! cloud single scattering albedo * tau
@@ -1091,8 +1094,18 @@ end function radiation_nextsw_cday
       call pbuf_get_field(pbuf, sd_idx, sd)
       call pbuf_get_field(pbuf, lu_idx, lu)
       call pbuf_get_field(pbuf, ld_idx, ld)
-    end if
- 
+   end if
+
+   !JPT 20250702: "rad_asym_splt" namelist switch partitions the flux within the RRMTG_SW split band
+   ! (Band 9, overlapping the 0.7micron) between the VIS/NIR coupling channels. The default (false)
+   ! splits flux in this band evenly between the VIS and NIR bands. Tolento et al. (2025) suggest
+   ! a ratio of 55.5/44.5 would be more appropriate, which results in cooling over cryospheric surfaces
+    if (rad_asym_splt) then 
+       vis_frc = 0.555_r8
+    else
+       vis_frc = 0.5_r8
+    endif
+    
     if (do_aerocom_ind3) then
       cld_tau_idx = pbuf_get_index('cld_tau')
     end if
@@ -1292,7 +1305,7 @@ end function radiation_nextsw_cday
                        state%pmid,   cldfprime,                                                &
                        aer_tau,      aer_tau_w,    aer_tau_w_g,  aer_tau_w_f,                  &
                        eccf,         coszrs,       solin,        sfac,                         &
-                       cam_in%asdir, cam_in%asdif, cam_in%aldir, cam_in%aldif,                 &
+                       cam_in%asdir, cam_in%asdif, cam_in%aldir, cam_in%aldif, vis_frc,         &
                        qrs,          qrsc,         fsnt,         fsntc,        fsntoa, fsutoa, &
                        fsntoac,      fsnirt,       fsnrtc,       fsnirtsq,     fsns,           &
                        fsnsc,        fsdsc,        fsds,         cam_out%sols, cam_out%soll,   &
@@ -1302,7 +1315,6 @@ end function radiation_nextsw_cday
                        E_cld_tau=c_cld_tau, E_cld_tau_w=c_cld_tau_w, E_cld_tau_w_g=c_cld_tau_w_g, E_cld_tau_w_f=c_cld_tau_w_f, &
                        old_convert = .false.)
                   call t_stopf ('rad_rrtmg_sw')
-
                   !  Output net fluxes at 200 mb
                   call vertinterp(ncol, pcols, pverp, state%pint, 20000._r8, fcns, fsn200c)
                   call vertinterp(ncol, pcols, pverp, state%pint, 20000._r8, fns, fsn200)

--- a/components/eam/src/physics/rrtmg/radsw.F90
+++ b/components/eam/src/physics/rrtmg/radsw.F90
@@ -41,7 +41,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
                     E_pmid   ,E_cld      ,                             &
                     E_aer_tau,E_aer_tau_w,E_aer_tau_w_g,E_aer_tau_w_f, &
                     eccf     ,E_coszrs   ,solin        ,sfac         , &
-                    E_asdir  ,E_asdif    ,E_aldir      ,E_aldif      , &
+                    E_asdir  ,E_asdif    ,E_aldir      ,E_aldif,   vis_frc, &
                     qrs      ,qrsc       ,fsnt         ,fsntc        ,fsntoa,fsutoa, &
                     fsntoac  ,fsnirtoa   ,fsnrtoac     ,fsnrtoaq     ,fsns    , &
                     fsnsc    ,fsdsc      ,fsds         ,sols         ,soll    , &
@@ -122,6 +122,8 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8), intent(in) :: E_aldir(pcols)     ! 0.7-5.0 micro-meter srfc alb: direct rad
    real(r8), intent(in) :: E_asdif(pcols)     ! 0.2-0.7 micro-meter srfc alb: diffuse rad
    real(r8), intent(in) :: E_aldif(pcols)     ! 0.7-5.0 micro-meter srfc alb: diffuse rad
+   real(r8), intent(in) :: vis_frc            ! Fraction flux flux blueward of 0.7microns
+                                              ! in rrtmg_sw split band 
    real(r8), intent(in) :: sfac(nbndsw)            ! factor to account for solar variability in each band 
    integer,  intent(inout) :: clm_rand_seed(pcols,4)            ! rand # seeds for sw
 
@@ -522,7 +524,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    call rrtmg_sw(lchnk, Nday, rrtmg_levs, icld,         &
                  pmidmb, pintmb, tlay, tlev, tsfc, &
                  h2ovmr, o3vmr, co2vmr, ch4vmr, o2vmr, n2ovmr, &
-                 asdir, asdif, aldir, aldif, &
+                 asdir, asdif, aldir, aldif, vis_frc, &
                  coszrs, eccf, dyofyr, solvar, &
                  inflgsw, iceflgsw, liqflgsw, &
                  cld_stosw, tauc_stosw, ssac_stosw, asmc_stosw, fsfc_stosw, &

--- a/components/eam/src/physics/rrtmg/radsw.F90
+++ b/components/eam/src/physics/rrtmg/radsw.F90
@@ -122,7 +122,7 @@ subroutine rad_rrtmg_sw(lchnk,ncol       ,rrtmg_levs   ,r_state      , &
    real(r8), intent(in) :: E_aldir(pcols)     ! 0.7-5.0 micro-meter srfc alb: direct rad
    real(r8), intent(in) :: E_asdif(pcols)     ! 0.2-0.7 micro-meter srfc alb: diffuse rad
    real(r8), intent(in) :: E_aldif(pcols)     ! 0.7-5.0 micro-meter srfc alb: diffuse rad
-   real(r8), intent(in) :: vis_frc            ! Fraction flux flux blueward of 0.7microns
+   real(r8), intent(in) :: vis_frc            ! Fraction of surface insolation blueward of 0.7microns
                                               ! in rrtmg_sw split band 
    real(r8), intent(in) :: sfac(nbndsw)            ! factor to account for solar variability in each band 
    integer,  intent(inout) :: clm_rand_seed(pcols,4)            ! rand # seeds for sw


### PR DESCRIPTION
Cherry-picked the following commits:
324aabd27ff063c0d4273c2ce9147763443470d4
e693bed58473505f4ce92b6037f9c22c4eb27d67
8404dd3445983141e5b3e8916c44d4314cbf5378

from PR: https://github.com/E3SM-Project/E3SM/pull/7488